### PR TITLE
fix arguments of Web3FunctionHardhat run function for test

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -32,7 +32,7 @@ const config: HardhatUserConfig = {
   w3f: {
     rootDir: "./web3-functions",
     debug: false,
-    networks: ["mumbai", "goerli", "baseGoerli"], //(multiChainProvider) injects provider for these networks
+    networks: ["mumbai", "goerli", "baseGoerli", "sepolia"], //(multiChainProvider) injects provider for these networks
   },
 
   namedAccounts: {
@@ -47,8 +47,8 @@ const config: HardhatUserConfig = {
     hardhat: {
       chainId: 31337,
       forking: {
-        url: `https://eth-goerli.g.alchemy.com/v2/${ALCHEMY_ID}`,
-        blockNumber: 8664000,
+        url: `https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_ID}`,
+        blockNumber: 5014000,
       },
     },
 

--- a/test/examples/CoingeckoOracle.test.ts
+++ b/test/examples/CoingeckoOracle.test.ts
@@ -19,7 +19,7 @@ describe("CoingeckoOracle Tests", function () {
   let oracle: CoingeckoOracle;
   let oracleW3f: Web3FunctionHardhat;
   let userArgs: Web3FunctionUserArgs;
-
+  
   before(async function () {
     await deployments.fixture();
 
@@ -35,8 +35,10 @@ describe("CoingeckoOracle Tests", function () {
   });
 
   it("canExec: true - First execution", async () => {
-    let { result } = await oracleW3f.run({ userArgs });
+    let { result } = await oracleW3f.run("onRun", { userArgs });
     result = result as Web3FunctionResultV2;
+
+    console.log(result);
 
     expect(result.canExec).to.equal(true);
     if (!result.canExec) throw new Error("!result.canExec");
@@ -51,7 +53,7 @@ describe("CoingeckoOracle Tests", function () {
   });
 
   it("canExec: false - After execution", async () => {
-    let { result } = await oracleW3f.run({ userArgs });
+    let { result } = await oracleW3f.run("onRun", { userArgs });
     result = result as Web3FunctionResultV2;
 
     expect(result.canExec).to.equal(false);
@@ -65,7 +67,7 @@ describe("CoingeckoOracle Tests", function () {
     const ONE_HOUR = 60 * 60;
     await time.increase(ONE_HOUR);
 
-    const { result } = await oracleW3f.run({ userArgs });
+    const { result } = await oracleW3f.run("onRun", { userArgs });
     expect(result.canExec).to.equal(true);
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -16,7 +16,7 @@ describe("HelloWorld Tests", function () {
   });
 
   it("Return canExec: true", async () => {
-    const { result } = await helloWorld.run();
+    const { result } = await helloWorld.run("onRun");
 
     expect(result.canExec).to.equal(true);
   });


### PR DESCRIPTION
- fix arguments of the Web3FunctionHardhat run function  for oracle and hello world test
- set default hardhat network fork to sepolia instead of goerli